### PR TITLE
Rename LocalGemma complete method to acomplete

### DIFF
--- a/providers/gemma.py
+++ b/providers/gemma.py
@@ -41,8 +41,9 @@ class LocalGemma:
             _singletons[model_id] = inst
             return inst
 
-    async def complete(self, system_prompt: str, messages: list[dict], max_tokens: int = 512) -> str:
-        # Very simple chat turn join; adapt as needed.
-        text = system_prompt.strip() + "\n" + "\n".join(f"{m.get('role','user')}: {m.get('content','')}" for m in messages)
+    async def acomplete(self, prompt: str, *, system: str = "", max_tokens: int = 512) -> str:
+        """Return model text output given a prompt and optional system message."""
+        system_text = f"{system.strip()}\n" if system else ""
+        text = system_text + f"user: {prompt}"
         out = self.runner.pipe(text, max_new_tokens=max_tokens, do_sample=False)
         return out[0]["generated_text"]


### PR DESCRIPTION
## Summary
- Rename `LocalGemma.complete` to `acomplete` to align with async interface
- Match `acomplete` signature with other providers and keep async behavior

## Testing
- `pytest`
- `python - <<'PY'
import asyncio, types, sys
ma = types.ModuleType('models.actions')
ma.parse_actions = lambda x: x
class ActionType:
    pass
ma.ActionType = ActionType
sys.modules['models.actions'] = ma

from interolog import Orchestrator
from providers.gemma import LocalGemma, _Runner

class DummyPipe:
    def __call__(self, text, max_new_tokens, do_sample):
        return [{"generated_text": "dummy"}]

llm = LocalGemma('test', _Runner(pipe=DummyPipe()))
o = Orchestrator(llm=llm)

async def main():
    res = await o.llm.acomplete('hi', system='sys')
    print('Result:', res)

asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a7b7961ae4832a8430f81f98a2ddb5