### PR TITLE
Add OpenAI and dotenv dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pydantic>=2
 transformers>=4.41
 torch
-
 aiohttp>=3.9
+openai>=1.0
+python-dotenv


### PR DESCRIPTION
## Summary
- add OpenAI and python-dotenv dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7b6e42544832a8b63556397751640