### PR TITLE
Track calling actor when invoking orchestrator APIs

### DIFF
--- a/tests/test_kill_policy.py
+++ b/tests/test_kill_policy.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from interolog import Orchestrator
+
+
+class DummyLLM:
+    async def acomplete(self, prompt: str, system: str = "") -> str:
+        return "{\"actions\": []}"
+
+
+@pytest.mark.asyncio
+async def test_sub_cannot_kill_other_sub():
+    o = Orchestrator(DummyLLM())
+    await o.start("do work", with_comms=True)
+    sub1 = await o.request_spawn(role="A", goal="g1", parent_id=o._main_id)
+    sub2 = await o.request_spawn(role="B", goal="g2", parent_id=o._main_id)
+    o.current_actor = sub1
+    res = await o.kill_with_policy(sub2.state.id)
+    assert res["ok"] is False
+    assert "sub may only kill self" in res["error"]
+    await o.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_sub_cannot_kill_comms():
+    o = Orchestrator(DummyLLM())
+    await o.start("do work", with_comms=True)
+    sub1 = await o.request_spawn(role="A", goal="g1", parent_id=o._main_id)
+    o.current_actor = sub1
+    res = await o.kill_with_policy(o._comms_id)
+    assert res["ok"] is False
+    assert res["error"]
+    await o.shutdown()


### PR DESCRIPTION
## Summary
- Track the calling monologue on the orchestrator via `current_actor`
- Ensure `current_actor` is set before action handlers and cleared afterwards
- Add regression tests that subs cannot terminate other subs or the comms actor

## Testing
- `pytest tests/test_kill_policy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7c0936d7c832aa48691fb161a61e9