### PR TITLE
feat: add direct question handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,15 @@ async def printer(inj: InjectionModel, main_state: MonologueStateModel):
 async def run(goal: str, dash: bool):
     llm = get_provider("hf_gemma")
     orch = Orchestrator(llm, on_injection=printer)
+
+    async def cli_question(cid: str, question: str, choices: list[str]):
+        print(f"[QUESTION {cid}] {question} choices={choices}")
+        loop = asyncio.get_running_loop()
+        reply = await loop.run_in_executor(None, lambda: input("> "))
+        await orch.on_user_message(reply, cid)
+
+    orch.on_question = cli_question
+
     await orch.start(main_goal=goal, with_comms=True)
     if dash and os.getenv("DASH_ENABLED","true").lower() == "true":
         from dashboard.tui import run_tui

--- a/tests/test_ask_user.py
+++ b/tests/test_ask_user.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from interolog import Orchestrator
+from action_registry import _handle_ask_user
+from models.actions import AskUser
+
+
+class DummyLLM:
+    async def acomplete(self, prompt, system=None):
+        return ""
+
+
+@pytest.mark.asyncio
+async def test_ask_user_waits_for_reply():
+    asked = {}
+
+    async def on_question(cid, question, choices):
+        asked["data"] = (cid, question, choices)
+
+    orch = Orchestrator(DummyLLM(), on_question=on_question)
+    mon = orch._spawn(role="Tester", goal="g", parent_id=None, immortal=True, llm=False)
+    model = AskUser(correlation_id="c1", question="Q?", choices=["y", "n"])
+
+    task = asyncio.create_task(_handle_ask_user(mon, model))
+    await asyncio.sleep(0.01)
+
+    assert asked["data"] == ("c1", "Q?", ["y", "n"])
+    assert not task.done()
+
+    await orch.on_user_message("yes", "c1")
+    await asyncio.sleep(0.01)
+
+    assert task.done()
+    assert await mon.inbox.get() == "[reply cid:c1] yes"


### PR DESCRIPTION
## Summary
- route ask_user prompts through a new `on_question` callback instead of the comms inbox
- update CLI/TUI to display questions and send replies with `on_user_message`
- add regression test for ask_user flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7c2bfad08832a9ca2e808a5056b51