### PR TITLE
Implement orchestrator improvements and expand tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.gitignore
+__pycache__
+.pytest_cache
+.venv
+venv
+*.pyc
+*.pyo
+*.pyd
+*.log
+htmlcov
+.coverage

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+*.sh text eol=lf
+*.py text eol=lf
+*.md text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Byte-compiled / cache
+__pycache__/
+*.py[cod]
+.Python
+.pytest_cache/
+
+# Virtual environments
+.env
+.venv/
+venv/
+
+# Coverage / reports
+.coverage
+coverage.xml
+htmlcov/
+
+# Editors
+.idea/
+.vscode/
+
+# Misc
+*.log
+*.tmp
+/.mypy_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Unreleased
+
+- Prevent duplicate actor task scheduling and add graceful orchestrator shutdown that awaits all running tasks.
+- Track last action, tool usage, inbox state, and errors on each monologue while persisting a rolling context buffer.
+- Surface discovered tool and action metadata directly in actor prompts.
+- Make HTTP tool imports lazy so optional dependencies no longer block startup and harden shell/file tool allowlists with real-path checks.
+- Expose `--provider`/`--model` CLI flags (and matching env vars) for selecting Gemma or OpenAI backends at runtime.
+- Expand async test coverage to include early-wake sleeps, message routing, and action/metadata handling.

--- a/README.md
+++ b/README.md
@@ -3,23 +3,30 @@
 
 Internal monologue orchestrator with:
 - Pydantic-typed actions with centralized handler registry (`action_registry.py`)
-- Tool registry (files, shell) with dry-run defaults
-- Live terminal dashboard (actors table, event feed, chat)
-- Telemetry queue + JSONL logging
-- Env-driven config
-- OpenAI async provider
+- Tool registry (files, shell, HTTP) auto-discovered at runtime and surfaced directly in actor prompts
+- Rich actor telemetry (context buffer, last action, tool usage, errors) and live terminal dashboard (actors table, event feed, chat)
+- Graceful shutdown semantics for clean embedding in other services
+- Env-driven configuration and CLI overrides for choosing LLM provider/model (local Gemma or OpenAI)
 
 ## Quickstart
 
 ```bash
-cd interolog_production
-cp .env.example .env
-# set OPENAI_API_KEY in .env
+pip install -r requirements.txt
+
+# Example: run with local Gemma (default)
 python main.py "Coordinate subs to research and report"
+
+# Example: target OpenAI
+OPENAI_API_KEY=sk-... python main.py --provider openai --model gpt-4o-mini "Coordinate subs to research and report"
 ```
 
 Use the terminal to type messages to the Comms monologue. Commands:
 - `/kill <actor_id>` stop a worker
 - `/quit` exit the dashboard
 
-Configure via `.env`. See `.env.example` for all keys.
+Configuration options can be supplied via environment variables or flags:
+- `INTEROLOG_PROVIDER` / `--provider`
+- `INTEROLOG_MODEL` / `--model`
+- `MAX_SUB_STEPS`, `MAX_CHILDREN`, `CYCLE_DELAY`, `COMMS_*` for orchestration tuning
+
+Tools are optional: if a dependency such as `aiohttp` is missing the corresponding tool will raise a helpful runtime error instead of blocking startup.

--- a/dashboard/tui.py
+++ b/dashboard/tui.py
@@ -1,10 +1,13 @@
-
 from __future__ import annotations
-import asyncio, os, sys, shutil
+
+import asyncio
+import shutil
+import sys
 from .state import DashboardState
 from .events import pump_events
 
 CLEAR = "\x1b[2J\x1b[H"
+
 
 def fmt_row(cols, widths):
     out = []
@@ -12,6 +15,7 @@ def fmt_row(cols, widths):
         s = (c if c is not None else "")[:w].ljust(w)
         out.append(s)
     return " ".join(out)
+
 
 async def input_loop(orchestrator, dbstate: DashboardState):
     loop = asyncio.get_running_loop()
@@ -21,7 +25,8 @@ async def input_loop(orchestrator, dbstate: DashboardState):
     while True:
         line = await reader.readline()
         if not line:
-            await asyncio.sleep(0.1); continue
+            await asyncio.sleep(0.1)
+            continue
         msg = line.decode(errors="replace").strip()
         if not msg:
             continue
@@ -29,7 +34,7 @@ async def input_loop(orchestrator, dbstate: DashboardState):
             if msg == "/quit":
                 raise KeyboardInterrupt
             elif msg.startswith("/kill "):
-                _, aid = msg.split(" ",1)
+                _, aid = msg.split(" ", 1)
                 await orchestrator.stop_child(aid.strip())
                 dbstate.add_chat(f"[sys] requested stop {aid}")
             else:
@@ -47,43 +52,46 @@ async def input_loop(orchestrator, dbstate: DashboardState):
                 dbstate.add_chat(f"[you] {msg}")
                 await orchestrator.on_user_message(msg)
 
+
 async def draw_loop(orchestrator, dbstate: DashboardState, refresh: float = 0.5):
     while True:
         cols = shutil.get_terminal_size((120, 40)).columns
         print(CLEAR, end="")
         print("Interolog Dashboard — Ctrl+C to exit".ljust(cols))
-        print("-"*cols)
-        headers = ["id","role","step","run","inbox","tools","last_action","err"]
-        widths = [8,12,4,3,5,5,28,28]
+        print("-" * cols)
+        headers = ["id", "role", "step", "run", "inbox", "tools", "last_action", "err"]
+        widths = [8, 12, 4, 3, 5, 5, 28, 28]
         print(fmt_row(headers, widths))
-        print("-"*cols)
+        print("-" * cols)
         for a in dbstate.actors[:20]:
             row = [
-                a.get("id",""),
-                a.get("role",""),
-                str(a.get("step",0)),
+                a.get("id", ""),
+                a.get("role", ""),
+                str(a.get("step", 0)),
                 "Y" if a.get("running") else "N",
-                str(a.get("inbox_size",0)),
-                str(a.get("tool_calls",0)),
-                a.get("last_action","")[:28],
-                a.get("last_error","")[:28],
+                str(a.get("inbox_size", 0)),
+                str(a.get("tool_calls", 0)),
+                a.get("last_action", "")[:28],
+                a.get("last_error", "")[:28],
             ]
             print(fmt_row(row, widths))
-        print("-"*cols)
+        print("-" * cols)
         print("Events:")
         for e in dbstate.events[-10:]:
-            et = e.get("type","evt")
+            et = e.get("type", "evt")
             s = e.get("summary", "") or str(e)
             print(f" - [{et}] {s}"[:cols])
-        print("-"*cols)
+        print("-" * cols)
         print("Chat: (type to send, @cid <msg> to reply, /kill <id>, /quit)")
         for line in dbstate.chat[-5:]:
             print(f" {line}"[:cols])
         sys.stdout.flush()
         await asyncio.sleep(refresh)
 
+
 async def run_tui(orchestrator, refresh: float = 0.5):
     dbstate = DashboardState()
+
     async def question_handler(cid, question, choices):
         dbstate.add_chat(f"[ask {cid}] {question} choices={choices}")
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,13 @@
-
 from __future__ import annotations
-import argparse, asyncio, os, sys
+
+import argparse
+import asyncio
+import os
+import sys
 
 try:
     from dotenv import load_dotenv  # type: ignore
+
     load_dotenv()
 except Exception:
     pass
@@ -13,11 +17,13 @@ from providers import get_provider
 from models.injections import InjectionModel
 from models.state import MonologueStateModel
 
+
 async def printer(inj: InjectionModel, main_state: MonologueStateModel):
     print(f"[MAIN<-{inj.from_id}] {inj.content}", flush=True)
 
-async def run(goal: str, dash: bool):
-    llm = get_provider("hf_gemma")
+
+async def run(goal: str, dash: bool, provider: str, model_id: str | None):
+    llm = get_provider(provider, model_id=model_id)
     orch = Orchestrator(llm, on_injection=printer)
 
     async def cli_question(cid: str, question: str, choices: list[str]):
@@ -29,10 +35,12 @@ async def run(goal: str, dash: bool):
     orch.on_question = cli_question
 
     await orch.start(main_goal=goal, with_comms=True)
-    if dash and os.getenv("DASH_ENABLED","true").lower() == "true":
+    if dash and os.getenv("DASH_ENABLED", "true").lower() == "true":
         from dashboard.tui import run_tui
-        await run_tui(orch, refresh=float(os.getenv("DASH_REFRESH","0.5")))
+
+        await run_tui(orch, refresh=float(os.getenv("DASH_REFRESH", "0.5")))
     else:
+
         async def forward_stdin():
             loop = asyncio.get_running_loop()
             while True:
@@ -48,12 +56,33 @@ async def run(goal: str, dash: bool):
         await stdin_task
     await orch.shutdown()
 
+
 def main():
-    p = argparse.ArgumentParser(description="Interolog Orchestrator (OpenAI provider)")
+    default_provider = os.getenv("INTEROLOG_PROVIDER", "hf_gemma")
+    default_model = os.getenv("INTEROLOG_MODEL")
+    p = argparse.ArgumentParser(description="Interolog Orchestrator")
     p.add_argument("goal", help="Initial main-goal prompt.")
     p.add_argument("--no-dash", action="store_true", help="Run headless (no TUI).")
+    p.add_argument(
+        "--provider",
+        default=default_provider,
+        help="LLM provider to use (e.g., hf_gemma, openai).",
+    )
+    p.add_argument(
+        "--model",
+        default=default_model,
+        help="Override model identifier for the selected provider.",
+    )
     args = p.parse_args()
-    asyncio.run(run(args.goal, dash=not args.no_dash))
+    asyncio.run(
+        run(
+            args.goal,
+            dash=not args.no_dash,
+            provider=args.provider,
+            model_id=args.model,
+        )
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/providers/gemma.py
+++ b/providers/gemma.py
@@ -1,27 +1,32 @@
 # v-axion-ai/providers/gemma.py
 # Purpose: Local Gemma provider using HuggingFace Transformers; singleton per model.
 from __future__ import annotations
-from typing import Optional, Any
+from typing import Any
 import asyncio
 import threading
 from dataclasses import dataclass
+
 
 # Lazy imports to avoid heavy startup
 def _lazy_imports():
     global AutoModelForCausalLM, AutoTokenizer, pipeline
     from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline  # type: ignore
 
+
 _singletons = {}
 _singletons_lock = threading.Lock()
+
 
 @dataclass
 class _Runner:
     pipe: Any
 
+
 class LocalGemma:
     """Singleton-backed local Gemma provider.
     Downloads model on first use into HF cache. Subsequent runs reuse it.
     """
+
     model_id: str
     runner: _Runner
 
@@ -42,7 +47,9 @@ class LocalGemma:
             _singletons[model_id] = inst
             return inst
 
-    async def acomplete(self, prompt: str, *, system: str = "", max_tokens: int = 512) -> str:
+    async def acomplete(
+        self, prompt: str, *, system: str = "", max_tokens: int = 512
+    ) -> str:
         """Return model text output given a prompt and optional system message.
 
         Offloads the blocking pipeline call to a thread to avoid blocking the

--- a/providers/openai.py
+++ b/providers/openai.py
@@ -1,8 +1,10 @@
-
 from __future__ import annotations
-import os, asyncio
+
+import asyncio
+import os
 
 from .base import LLM
+
 
 class OpenAIChat(LLM):
     """OpenAI chat completions provider using the async SDK.
@@ -12,7 +14,13 @@ class OpenAIChat(LLM):
       OPENAI_MODEL (default: gpt-4o-mini)
       OPENAI_TIMEOUT (default: 30 seconds)
     """
-    def __init__(self, model: str | None = None, api_key: str | None = None, timeout: float | None = None):
+
+    def __init__(
+        self,
+        model: str | None = None,
+        api_key: str | None = None,
+        timeout: float | None = None,
+    ):
         self.model = model or os.getenv("OPENAI_MODEL", "gpt-4o-mini")
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self.timeout = float(timeout or os.getenv("OPENAI_TIMEOUT", 30))
@@ -22,21 +30,29 @@ class OpenAIChat(LLM):
         try:
             from openai import AsyncOpenAI  # type: ignore
         except Exception as e:
-            raise RuntimeError("openai package not installed. `pip install openai`") from e
+            raise RuntimeError(
+                "openai package not installed. `pip install openai`"
+            ) from e
 
         self.client = AsyncOpenAI(api_key=self.api_key)
 
-    async def acomplete(self, prompt: str, *, system: str = "", max_tokens: int = 400) -> str:
+    async def acomplete(
+        self, prompt: str, *, system: str = "", max_tokens: int = 400
+    ) -> str:
         from openai import APIConnectionError, RateLimitError  # type: ignore
+
         try:
             resp = await asyncio.wait_for(
                 self.client.chat.completions.create(
                     model=self.model,
-                    messages=[{"role":"system","content":system},{"role":"user","content":prompt}],
+                    messages=[
+                        {"role": "system", "content": system},
+                        {"role": "user", "content": prompt},
+                    ],
                     max_tokens=max_tokens,
                     temperature=0.2,
                 ),
-                timeout=self.timeout
+                timeout=self.timeout,
             )
             msg = resp.choices[0].message.content or "{}"
             return msg

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ torch
 aiohttp>=3.9
 openai>=1.0
 python-dotenv
+pytest-asyncio>=1.2

--- a/tests/test_kill_policy.py
+++ b/tests/test_kill_policy.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import sys
 
@@ -11,7 +10,7 @@ from interolog import Orchestrator
 
 class DummyLLM:
     async def acomplete(self, prompt: str, system: str = "") -> str:
-        return "{\"actions\": []}"
+        return '{"actions": []}'
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_behaviors.py
+++ b/tests/test_runtime_behaviors.py
@@ -1,0 +1,93 @@
+import asyncio
+import os
+import sys
+
+import pytest
+from pydantic import BaseModel
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from interolog import Monologue, Orchestrator  # noqa: E402
+from models.actions import ActionName, InjectAction, ToolAction  # noqa: E402
+from models.state import MonologueStateModel  # noqa: E402
+from tool_registry import ToolError, registry  # noqa: E402
+
+
+class DummyLLM:
+    async def acomplete(
+        self, prompt: str, system: str = ""
+    ) -> str:  # pragma: no cover - test double
+        return '{"actions": []}'
+
+
+class EchoInput(BaseModel):
+    message: str
+
+
+async def _echo_tool(message: str) -> dict[str, str]:
+    await asyncio.sleep(0)
+    return {"echo": message}
+
+
+def _ensure_test_tool() -> None:
+    if "test.echo" in registry.list():
+        return
+    try:
+        registry.register(
+            "test.echo", _echo_tool, model=EchoInput, description="Echo test tool"
+        )
+    except ToolError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_sleep_with_early_wake():
+    orch = Orchestrator(DummyLLM())
+    await orch.start("stay alert", with_comms=False)
+    task = asyncio.create_task(orch.sleep_with_early_wake(orch._main_id, 1.0))  # type: ignore[arg-type]
+    await asyncio.sleep(0.05)
+    await orch.notify_actor_message(orch._main_id)  # type: ignore[arg-type]
+    woke = await asyncio.wait_for(task, 0.5)
+    assert woke is True
+    await orch.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_route_incoming_sets_reply():
+    orch = Orchestrator(DummyLLM())
+    await orch.start("receive", with_comms=False)
+    req_id = "req123"
+    waiter = asyncio.create_task(orch.await_reply(req_id))
+    await asyncio.sleep(0)
+    payload = {"from_id": "tester", "reply_to": req_id, "content": "done"}
+    await orch.route_incoming(orch._main_id, payload)  # type: ignore[arg-type]
+    reply = await asyncio.wait_for(waiter, 0.5)
+    assert isinstance(reply, dict)
+    assert reply["content"] == "done"
+    await orch.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_records_state_and_tool_usage():
+    orch = Orchestrator(DummyLLM())
+    state = MonologueStateModel(id="mono1", role="Tester", goal="exercise actions")
+    mono = Monologue(orch, state, immortal=False, use_llm=True)
+
+    _ensure_test_tool()
+
+    inject = InjectAction(type=ActionName.INJECT, content="hello")
+    await mono._dispatch_actions([inject])
+    injected = await orch._main_inbox.get()
+    assert injected.content == "hello"
+    assert mono.state.last_action == "inject"
+    assert any(entry.startswith("inject:") for entry in mono.context_buffer)
+
+    tool = ToolAction(type=ActionName.TOOL, name="test.echo", args={"message": "ping"})
+    await mono._dispatch_actions([tool])
+    assert mono.state.tool_calls == 1
+    assert mono.state.last_action == "tool"
+    tool_msg = await mono.inbox.get()
+    assert "test.echo" in tool_msg
+    assert any("tool:test.echo" in entry for entry in mono.context_buffer)
+
+    await orch.shutdown()

--- a/tools/files.py
+++ b/tools/files.py
@@ -1,10 +1,13 @@
 # v-axion-ai/tools/files.py
 # Purpose: File I/O tools with env-based allowlist and Pydantic validation.
 from __future__ import annotations
+
 import os
-from typing import Dict, Any, List
+from pathlib import Path
+from typing import Any, Dict, List
 from pydantic import BaseModel, Field
 from tool_registry import tool
+
 
 def _allowed_paths() -> List[str]:
     raw = os.getenv("FILES_ALLOWED", "all").strip()
@@ -12,38 +15,56 @@ def _allowed_paths() -> List[str]:
         return ["all"]
     return [p.strip() for p in raw.split(",") if p.strip()]
 
+
 def _check_path(path: str) -> None:
     allowed = _allowed_paths()
     if "all" in allowed:
         return
-    norm = os.path.abspath(path)
+    norm = Path(path).expanduser().resolve()
     for prefix in allowed:
-        if norm.startswith(os.path.abspath(prefix)):
+        base = Path(prefix).expanduser().resolve()
+        if norm == base or base in norm.parents:
             return
     raise PermissionError(f"File access not allowed: {path}")
 
+
 class FileReadParams(BaseModel):
     path: str = Field(min_length=1)
+
 
 class FileWriteParams(BaseModel):
     path: str = Field(min_length=1)
     content: str
 
+
 class FileAppendParams(BaseModel):
     path: str = Field(min_length=1)
     content: str
 
+
 class FileDeleteParams(BaseModel):
     path: str = Field(min_length=1)
 
-@tool("file.read", model=FileReadParams, description="Read text file.", instructions="Provide 'path'; returns {'path','content'}")
+
+@tool(
+    "file.read",
+    model=FileReadParams,
+    description="Read text file.",
+    instructions="Provide 'path'; returns {'path','content'}",
+)
 async def file_read(path: str) -> Dict[str, Any]:
     """Read whole file as UTF-8 text."""
     _check_path(path)
     with open(path, "r", encoding="utf-8", errors="ignore") as f:
         return {"path": path, "content": f.read()}
 
-@tool("file.write", model=FileWriteParams, description="Write/overwrite text file.", instructions="Provide 'path' and 'content'.")
+
+@tool(
+    "file.write",
+    model=FileWriteParams,
+    description="Write/overwrite text file.",
+    instructions="Provide 'path' and 'content'.",
+)
 async def file_write(path: str, content: str) -> Dict[str, Any]:
     """Overwrite file contents."""
     _check_path(path)
@@ -51,7 +72,13 @@ async def file_write(path: str, content: str) -> Dict[str, Any]:
         f.write(content)
     return {"path": path, "status": "written"}
 
-@tool("file.append", model=FileAppendParams, description="Append text to file.", instructions="Provide 'path' and 'content'.")
+
+@tool(
+    "file.append",
+    model=FileAppendParams,
+    description="Append text to file.",
+    instructions="Provide 'path' and 'content'.",
+)
 async def file_append(path: str, content: str) -> Dict[str, Any]:
     """Append text to file."""
     _check_path(path)
@@ -59,7 +86,13 @@ async def file_append(path: str, content: str) -> Dict[str, Any]:
         f.write(content)
     return {"path": path, "status": "appended"}
 
-@tool("file.delete", model=FileDeleteParams, description="Delete file.", instructions="Provide 'path'.")
+
+@tool(
+    "file.delete",
+    model=FileDeleteParams,
+    description="Delete file.",
+    instructions="Provide 'path'.",
+)
 async def file_delete(path: str) -> Dict[str, Any]:
     """Delete target file."""
     _check_path(path)

--- a/tools/http_request.py
+++ b/tools/http_request.py
@@ -1,19 +1,32 @@
-
 # tools/http_request.py
 # Purpose: Async HTTP client tool (GET, POST, OPTIONS, HEAD) for APIs, headers, or raw source.
 from __future__ import annotations
-import asyncio
-from typing import Any, Dict, Optional, Literal, Union
+
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Union
 from pydantic import BaseModel, AnyUrl, Field, validator
 from tool_registry import tool
-import aiohttp
+
+try:  # pragma: no cover - optional dependency
+    import aiohttp  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    aiohttp = None  # type: ignore
+
+if TYPE_CHECKING:  # pragma: no cover
+    from aiohttp import ClientResponse  # type: ignore
+else:
+    ClientResponse = Any  # type: ignore
 
 DEFAULT_TIMEOUT = 30
 UA = "v-axion-ai/1.0 (+https://vontainment.com)"
 
+
 class HTTPInput(BaseModel):
-    action: Literal["headers", "request", "source"] = Field(..., description="Which operation to perform")
-    method: Literal["GET", "POST", "OPTIONS", "HEAD"] = Field("GET", description="HTTP method for 'request'")
+    action: Literal["headers", "request", "source"] = Field(
+        ..., description="Which operation to perform"
+    )
+    method: Literal["GET", "POST", "OPTIONS", "HEAD"] = Field(
+        "GET", description="HTTP method for 'request'"
+    )
     url: AnyUrl = Field(..., description="Target URL (http or https)")
     headers: Optional[Dict[str, str]] = None
     params: Optional[Dict[str, Union[str, int, float]]] = None
@@ -26,17 +39,22 @@ class HTTPInput(BaseModel):
     def _normalize_method(cls, v: str) -> str:
         return v.upper()
 
-async def _to_text(resp: aiohttp.ClientResponse) -> str:
+
+async def _to_text(resp: ClientResponse) -> str:
     try:
         return await resp.text()
     except UnicodeDecodeError:
         b = await resp.read()
         return b.decode("latin-1", errors="replace")
 
+
 def _slim_headers(h) -> Dict[str, str]:
     return {k: v for k, v in h.items()}
 
-async def _do_request(session: aiohttp.ClientSession, inp: HTTPInput) -> aiohttp.ClientResponse:
+
+async def _do_request(
+    session: "aiohttp.ClientSession", inp: HTTPInput
+) -> ClientResponse:
     kwargs: Dict[str, Any] = {
         "headers": inp.headers or {},
         "params": inp.params or {},
@@ -48,6 +66,7 @@ async def _do_request(session: aiohttp.ClientSession, inp: HTTPInput) -> aiohttp
         kwargs["data"] = inp.data
     return await session.request(inp.method, str(inp.url), **kwargs)
 
+
 @tool(
     name="http_request",
     model=HTTPInput,
@@ -56,47 +75,71 @@ async def _do_request(session: aiohttp.ClientSession, inp: HTTPInput) -> aiohttp
         "action='headers' -> returns response headers.\n"
         "action='request' -> API call with status, headers, and JSON/text.\n"
         "action='source'  -> GETs page and returns raw HTML/source."
-    )
+    ),
 )
 async def http_request(inp: HTTPInput) -> Dict[str, Any]:
+    if aiohttp is None:
+        raise RuntimeError(
+            "aiohttp is required for http_request tool. Install aiohttp to enable it."
+        )
     timeout = aiohttp.ClientTimeout(total=inp.timeout)
     base_headers = {"User-Agent": UA}
     if inp.headers:
         base_headers.update(inp.headers)
 
-    async with aiohttp.ClientSession(timeout=timeout, headers=base_headers, trust_env=True) as session:
+    async with aiohttp.ClientSession(
+        timeout=timeout, headers=base_headers, trust_env=True
+    ) as session:
         if inp.action == "headers":
             try:
-                resp = await session.request("HEAD", str(inp.url), allow_redirects=inp.allow_redirects)
+                resp = await session.request(
+                    "HEAD", str(inp.url), allow_redirects=inp.allow_redirects
+                )
                 async with resp:
-                    return {"action":"headers","status":resp.status,"url":str(resp.url),"headers":_slim_headers(resp.headers)}
+                    return {
+                        "action": "headers",
+                        "status": resp.status,
+                        "url": str(resp.url),
+                        "headers": _slim_headers(resp.headers),
+                    }
             except aiohttp.ClientResponseError:
                 pass
-            resp = await session.request("GET", str(inp.url), allow_redirects=inp.allow_redirects)
+            resp = await session.request(
+                "GET", str(inp.url), allow_redirects=inp.allow_redirects
+            )
             async with resp:
-                return {"action":"headers","status":resp.status,"url":str(resp.url),"headers":_slim_headers(resp.headers)}
+                return {
+                    "action": "headers",
+                    "status": resp.status,
+                    "url": str(resp.url),
+                    "headers": _slim_headers(resp.headers),
+                }
 
         if inp.action == "source":
             resp = await session.get(str(inp.url), allow_redirects=inp.allow_redirects)
             async with resp:
                 text = await _to_text(resp)
-                return {"action":"source","status":resp.status,"url":str(resp.url),
-                        "content_type":resp.headers.get("content-type"),
-                        "encoding":resp.charset,
-                        "headers":_slim_headers(resp.headers),
-                        "text":text}
+                return {
+                    "action": "source",
+                    "status": resp.status,
+                    "url": str(resp.url),
+                    "content_type": resp.headers.get("content-type"),
+                    "encoding": resp.charset,
+                    "headers": _slim_headers(resp.headers),
+                    "text": text,
+                }
 
         # action == "request"
         resp = await _do_request(session, inp)
         async with resp:
             result: Dict[str, Any] = {
-                "action":"request",
-                "status":resp.status,
-                "url":str(resp.url),
-                "method":inp.method,
-                "headers":_slim_headers(resp.headers),
+                "action": "request",
+                "status": resp.status,
+                "url": str(resp.url),
+                "method": inp.method,
+                "headers": _slim_headers(resp.headers),
             }
-            if inp.method in ("HEAD","OPTIONS"):
+            if inp.method in ("HEAD", "OPTIONS"):
                 return result
             try:
                 result["json"] = await resp.json(content_type=None)

--- a/tools/shell.py
+++ b/tools/shell.py
@@ -1,10 +1,16 @@
 # v-axion-ai/tools/shell.py
 # Purpose: Shell execution tool with env-based allowlist and Pydantic validation.
 from __future__ import annotations
-import os, asyncio, shlex
-from typing import Dict, Any, List
+
+import asyncio
+import os
+import shlex
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List
 from pydantic import BaseModel, Field
 from tool_registry import tool
+
 
 def _allowed_cmds() -> List[str]:
     raw = os.getenv("SHELL_ALLOWED", "all").strip()
@@ -12,18 +18,50 @@ def _allowed_cmds() -> List[str]:
         return ["all"]
     return [c.strip() for c in raw.split(",") if c.strip()]
 
+
 def _check_cmd(command: str) -> None:
     allowed = _allowed_cmds()
     if "all" in allowed:
         return
-    prog = shlex.split(command)[0] if command.strip() else ""
-    if prog not in allowed:
-        raise PermissionError(f"Shell command not allowed: {prog or '<empty>'}")
+    parts = shlex.split(command)
+    if not parts:
+        raise PermissionError("Shell command not allowed: <empty>")
+    prog = parts[0]
+    resolved: Path | None
+    if os.path.sep in prog:
+        resolved = Path(prog).expanduser().resolve()
+    else:
+        located = shutil.which(prog)
+        resolved = Path(located).resolve() if located else None
+    for entry in allowed:
+        if os.path.sep in entry:
+            target = Path(entry).expanduser().resolve()
+            if resolved is None:
+                continue
+            if target.is_dir():
+                try:
+                    resolved.relative_to(target)
+                    return
+                except ValueError:
+                    continue
+            if resolved == target:
+                return
+        else:
+            if prog == entry:
+                return
+    raise PermissionError(f"Shell command not allowed: {prog}")
+
 
 class ShellRunParams(BaseModel):
     command: str = Field(min_length=1)
 
-@tool("shell.run", model=ShellRunParams, description="Execute a shell command.", instructions="Provide 'command'; returns stdout/stderr/returncode.")
+
+@tool(
+    "shell.run",
+    model=ShellRunParams,
+    description="Execute a shell command.",
+    instructions="Provide 'command'; returns stdout/stderr/returncode.",
+)
 async def shell_run(command: str) -> Dict[str, Any]:
     """Run the given shell command using /bin/sh -c and capture output."""
     _check_cmd(command)


### PR DESCRIPTION
## Summary
- refactor orchestrator task management to avoid duplicate actor loops, expose richer monologue telemetry, and embed tool/action metadata in prompts
- harden optional tool loading and path/command allowlists while surfacing provider selection through new CLI flags and documentation
- add CHANGELOG entries, housekeeping dotfiles, and new async regression tests that cover wake/sleep, routing, and action metadata updates

## Testing
- ruff check
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3cba3a798832aa2276759da75d7ba