### PR TITLE
Add pytest async runner and document development workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Expose `--provider`/`--model` CLI flags (and matching env vars) for selecting Gemma or OpenAI backends at runtime.
 - Expand async test coverage to include early-wake sleeps, message routing, and action/metadata handling.
 - Ship a real-time web dashboard with chat, live monologue list, and modal inspector alongside new UI CLI/env configuration options.
+- Add a lightweight pytest hook so coroutine-based tests run without external plugins.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,15 @@ Configuration options can be supplied via environment variables or flags:
 - `MAX_SUB_STEPS`, `MAX_CHILDREN`, `CYCLE_DELAY`, `COMMS_*` for orchestration tuning
 
 Tools are optional: if a dependency such as `aiohttp` is missing the corresponding tool will raise a helpful runtime error instead of blocking startup.
+
+## Development
+
+The test suite relies on `async def` coroutines. A lightweight `conftest.py` plugin is included so the suite runs without third-party pytest extensions. To exercise the checks locally:
+
+```bash
+# Basic syntax/lint gate
+python -m py_compile $(git ls-files '*.py')
+
+# Run the async-enabled tests
+pytest
+```

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,37 @@
+"""Pytest configuration for running asyncio tests without external plugins."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the custom ``asyncio`` marker used throughout the test suite."""
+
+    config.addinivalue_line(
+        "markers",
+        "asyncio: mark a test as running inside an asyncio event loop",
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    """Execute ``async def`` tests by driving them with a fresh event loop."""
+
+    test_function = pyfuncitem.obj
+    if not inspect.iscoroutinefunction(test_function):
+        return None
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(test_function(**pyfuncitem.funcargs))
+        loop.run_until_complete(loop.shutdown_asyncgens())
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+    return True


### PR DESCRIPTION
## Summary
- add a lightweight conftest hook that runs coroutine-based pytest tests without external plugins
- document the new test workflow in the README and changelog, including the syntax gate command

## Testing
- python -m py_compile $(git ls-files '*.py')
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3d9948d80832a89916d4524aee827